### PR TITLE
Fix TypeError: Cannot read property 'startsWith' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,8 +161,8 @@ function componentSourceNameCheck(context, node) {
 
 function componentSourceDescriptionCheck(context, node) {
   const nameProp = checkComponentIsSourceAndReturnTargetProp(node, "description");
-  if (!nameProp) return;
-  if (!nameProp?.value?.value.startsWith("Emit new ")) {
+  if (!nameProp || typeof nameProp?.value?.value !== 'string') return;
+  if (!nameProp.value.value.startsWith("Emit new ")) {
     context.report({
       node: nameProp,
       message: "Source descriptions should start with \"Emit new\". See https://pipedream.com/docs/components/guidelines/#source-description",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
```
compwright@Jonathons-MacBook-Pro pipedream % npx eslint components/mailgun

Oops! Something went wrong! :(

ESLint: 7.26.0

TypeError: Cannot read property 'startsWith' of undefined
Occurred while linting /Users/compwright/Development/pipedream/components/mailgun/sources/new-click/new-click.js:6
    at componentSourceDescriptionCheck (/Users/compwright/Development/pipedream/node_modules/eslint-plugin-pipedream/index.js:165:30)
    at ExpressionStatement (/Users/compwright/Development/pipedream/node_modules/eslint-plugin-pipedream/index.js:260:13)
    at /Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/node-event-generator.js:256:26)
    at NodeEventGenerator.applySelectors (/Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/node-event-generator.js:285:22)
    at NodeEventGenerator.enterNode (/Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/node-event-generator.js:299:14)
    at CodePathAnalyzer.enterNode (/Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:711:23)
    at /Users/compwright/Development/pipedream/node_modules/eslint/lib/linter/linter.js:954:32
```