### PR TITLE
Fix eslint failing with TypeError when default export is not an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,24 @@ function isObjectWithProperties(node) {
   return true;
 }
 
+function getComponentFromNode(node) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
+    return node.declaration;
+  }
+
+  if (node.expression) {
+    const {
+      left,
+      right,
+    } = node.expression;
+    if (isModuleExports(left) && isObjectWithProperties(right)) {
+      return right;
+    }
+  }
+
+  return null;
+}
+
 // Objects can contain key names surrounded by quotes, or not
 // propertyArray is the array of Property nodes in the component object
 function astIncludesProperty(name, propertyArray) {
@@ -44,20 +62,7 @@ function findPropertyWithName(name, propertyArray) {
 
 // Does a component contain the right property? e.g. key, version
 function componentContainsPropertyCheck(context, node, propertyName, message) {
-  let component;
-  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
-    component = node.declaration;
-  }
-
-  if (node.expression) {
-    const {
-      left,
-      right,
-    } = node.expression;
-    if (isModuleExports(left) && isObjectWithProperties(right)) {
-      component = right;
-    }
-  }
+  const component = getComponentFromNode(node);
 
   if (!component) return;
   if (!astIncludesProperty(propertyName, component.properties)) {
@@ -80,19 +85,7 @@ function getProps(moduleProperties) {
 
 // Do component props contain the right properties? e.g. label, description
 function componentPropsContainsPropertyCheck(context, node, propertyName) {
-  let component;
-  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
-    component = node.declaration;
-  }
-  if (node.expression) {
-    const {
-      left,
-      right,
-    } = node.expression;
-    if (isModuleExports(left) && isObjectWithProperties(right)) {
-      component = right;
-    }
-  }
+  const component = getComponentFromNode(node);
 
   if (!component) return;
 
@@ -119,20 +112,7 @@ function componentPropsContainsPropertyCheck(context, node, propertyName) {
 }
 
 function optionalComponentPropsHaveDefaultProperty(context, node) {
-  let component;
-  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
-    component = node.declaration;
-  }
-
-  if (node.expression) {
-    const {
-      left,
-      right,
-    } = node.expression;
-    if (isModuleExports(left) && isObjectWithProperties(right)) {
-      component = right;
-    }
-  }
+  const component = getComponentFromNode(node);
 
   if (!component) return;
   const { properties } = component;
@@ -166,20 +146,7 @@ function optionalComponentPropsHaveDefaultProperty(context, node) {
 // Checks to confirm the component is a source, and returns
 // the node with the name specified by the user
 function checkComponentIsSourceAndReturnTargetProp(node, propertyName) {
-  let component;
-  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
-    component = node.declaration;
-  }
-
-  if (node.expression) {
-    const {
-      left,
-      right,
-    } = node.expression;
-    if (isModuleExports(left) && isObjectWithProperties(right)) {
-      component = right;
-    }
-  }
+  const component = getComponentFromNode(node);
 
   if (!component) return;
   const { properties } = component;
@@ -215,20 +182,7 @@ function componentSourceDescriptionCheck(context, node) {
 }
 
 function componentVersionTsMacroCheck(context, node) {
-  let component;
-  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
-    component = node.declaration;
-  }
-
-  if (node.expression) {
-    const {
-      left,
-      right,
-    } = node.expression;
-    if (isModuleExports(left) && isObjectWithProperties(right)) {
-      component = right;
-    }
-  }
+  const component = getComponentFromNode(node);
 
   if (!component) return;
   const { properties } = component;

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function findPropertyWithName(name, propertyArray) {
 // Does a component contain the right property? e.g. key, version
 function componentContainsPropertyCheck(context, node, propertyName, message) {
   let component;
-  if (isDefaultExport(node)) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     component = node.declaration;
   }
 
@@ -81,7 +81,7 @@ function getProps(moduleProperties) {
 // Do component props contain the right properties? e.g. label, description
 function componentPropsContainsPropertyCheck(context, node, propertyName) {
   let component;
-  if (isDefaultExport(node)) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     component = node.declaration;
   }
   if (node.expression) {
@@ -120,7 +120,7 @@ function componentPropsContainsPropertyCheck(context, node, propertyName) {
 
 function optionalComponentPropsHaveDefaultProperty(context, node) {
   let component;
-  if (isDefaultExport(node)) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     component = node.declaration;
   }
 
@@ -167,7 +167,7 @@ function optionalComponentPropsHaveDefaultProperty(context, node) {
 // the node with the name specified by the user
 function checkComponentIsSourceAndReturnTargetProp(node, propertyName) {
   let component;
-  if (isDefaultExport(node)) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     component = node.declaration;
   }
 
@@ -216,7 +216,7 @@ function componentSourceDescriptionCheck(context, node) {
 
 function componentVersionTsMacroCheck(context, node) {
   let component;
-  if (isDefaultExport(node)) {
+  if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     component = node.declaration;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changelog
- Fix eslint failing with `TypeError` when default export is not an object (with properties)
- Refactor reused logic for getting component from CJS and ESM files into separate function

### Context

When linting `.mjs` files with a `default export` that is **not** an object, ESLint throws `TypeError: Cannot read property 'map' of undefined`.
This error happens because [`propertyArray.map()`](https://github.com/PipedreamHQ/eslint-plugin-pipedream/blob/6b0f0a555da655fc9c876522bc943949875b36df/index.js#L27) is called in cases where `propertyArray` could be `undefined` instead of an array. Specifically, in component checks where [`isDefaultExport(node)`](https://github.com/PipedreamHQ/eslint-plugin-pipedream/blob/6b0f0a555da655fc9c876522bc943949875b36df/index.js#L48), but [`node.declaration`](https://github.com/PipedreamHQ/eslint-plugin-pipedream/blob/6b0f0a555da655fc9c876522bc943949875b36df/index.js#L49) is something other than an `ObjectExpression` (e.g. an `ArrayExpression`), `node.declaration.properties` (i.e. [`component.properties`](https://github.com/PipedreamHQ/eslint-plugin-pipedream/blob/6b0f0a555da655fc9c876522bc943949875b36df/index.js#L63)) is `undefined`.

For example:
ESLint would fail when linting this file ([`region-data.mjs`](https://github.com/PipedreamHQ/pipedream/blob/5e5832e81ba8fd2a1f55745221ff480ea41257e3/components/reddit/sources/new-hot-posts-on-a-subreddit/region-data.mjs)):
```js
export default [
  "GLOBAL",
  "US",
  "AR",
  "AU",
]
```
- ESLint: 7.26.0
- eslint-plugin-pipedream: 0.2.2

**To reproduce:**
1. Clone https://github.com/PipedreamHQ/pipedream
2. Checkout commit `5e5832e81ba8fd2a1f55745221ff480ea41257e3` of branch `feature/reddit-new-actions`
3. Install dependencies
```
npm ci
```
4. Run ESLint
```
npx eslint components/reddit
```

