### PR TITLE
Fix default interface props

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ function isObjectWithProperties(node) {
 // Default interface props don't need labels and descriptions
 function isDefaultInterfaceProperty(propertyName, properties) {
   if (propertyName === "label" || propertyName === "description") {
-    const interfacePropValue = findPropertyWithName("type", properties).value;
-    return (interfacePropValue.value === "$.interface.timer" || interfacePropValue.value === "$.interface.http");
+    const interfacePropValue = findPropertyWithName("type", properties)?.value;
+    return (interfacePropValue?.value === "$.interface.timer" || interfacePropValue?.value === "$.interface.http");
   }
   return false;
 }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,15 @@ function isObjectWithProperties(node) {
   return true;
 }
 
+// Default interface props don't need labels and descriptions
+function isDefaultInterfaceProperty(propertyName, properties) {
+  if (propertyName === "label" || propertyName === "description") {
+    const interfacePropValue = findPropertyWithName("type", properties).value;
+    return (interfacePropValue.value === "$.interface.timer" || interfacePropValue.value === "$.interface.http");
+  }
+  return false;
+}
+
 function getComponentFromNode(node) {
   if (isDefaultExport(node) && isObjectWithProperties(node.declaration)) {
     return node.declaration;
@@ -102,6 +111,7 @@ function componentPropsContainsPropertyCheck(context, node, propertyName) {
     // We don't want to lint app props or props that are defined in propDefinitions
     if (!isObjectWithProperties(propDef)) continue;
     if (astIncludesProperty("propDefinition", propDef.properties)) continue;
+    if (isDefaultInterfaceProperty(propertyName, propDef.properties)) continue;
     if (!astIncludesProperty(propertyName, propDef.properties)) {
       context.report({
         node: prop,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",
   "scripts": {

--- a/tests/components.js
+++ b/tests/components.js
@@ -71,6 +71,30 @@ module.exports = {
       },
     },
   },
+  missingPropsLabelTimer: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "$.interface.timer",
+        description: "test",
+      },
+    },
+  },
+  missingPropsLabelHttp: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "$.interface.http",
+        description: "test",
+      },
+    },
+  },
   missingPropsDescription: {
     key: "test",
     name: "Test",
@@ -79,6 +103,30 @@ module.exports = {
     props: {
       test: {
         type: "string",
+        label: "Test",
+      },
+    },
+  },
+  missingPropsDescriptionTimer: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "$.interface.timer",
+        label: "Test",
+      },
+    },
+  },
+  missingPropsDescriptionHttp: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "$.interface.http",
         label: "Test",
       },
     },

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -9,7 +9,11 @@ const {
   requiredPropertyTypeMissing,
   optionalPropWithoutDefaultValue,
   missingPropsLabel,
+  missingPropsLabelTimer,
+  missingPropsLabelHttp,
   missingPropsDescription,
+  missingPropsDescriptionTimer,
+  missingPropsDescriptionHttp,
   badSourceName,
   badSourceDescription,
   tsVersion,
@@ -87,11 +91,25 @@ const componentTestConfigs = [
   },
   {
     ruleName: "props-label",
+    validComponent: missingPropsLabelTimer,
+    invalidComponent: missingPropsLabel,
+    errorMessage: "Component prop test must have a label. See https://pipedream.com/docs/components/guidelines/#props",
+  },
+  {
+    ruleName: "props-label",
+    validComponent: missingPropsLabelHttp,
     invalidComponent: missingPropsLabel,
     errorMessage: "Component prop test must have a label. See https://pipedream.com/docs/components/guidelines/#props",
   },
   {
     ruleName: "props-description",
+    validComponent: missingPropsDescriptionTimer,
+    invalidComponent: missingPropsDescription,
+    errorMessage: "Component prop test must have a description. See https://pipedream.com/docs/components/guidelines/#props",
+  },
+  {
+    ruleName: "props-description",
+    validComponent: missingPropsDescriptionHttp,
     invalidComponent: missingPropsDescription,
     errorMessage: "Component prop test must have a description. See https://pipedream.com/docs/components/guidelines/#props",
   },
@@ -184,4 +202,3 @@ RuleTester.describe("On ESM export default with preceding statements", () => {
     });
   });
 });
-


### PR DESCRIPTION
Removes `label` and `description` requirements when prop is a `timer` or `http` interface.

This PR addresses issue #1.