### PR TITLE
fix: exclude 'dir' props from label and description requirements

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js 14.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 14.x
         cache: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-pipedream",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",
   "scripts": {

--- a/tests/components.js
+++ b/tests/components.js
@@ -95,6 +95,18 @@ module.exports = {
       },
     },
   },
+  missingPropsLabelDir: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "dir",
+        description: "test",
+      },
+    },
+  },
   missingPropsDescription: {
     key: "test",
     name: "Test",
@@ -127,6 +139,18 @@ module.exports = {
     props: {
       test: {
         type: "$.interface.http",
+        label: "Test",
+      },
+    },
+  },
+  missingPropsDescriptionDir: {
+    key: "test",
+    name: "Test",
+    description: "hello",
+    version: "0.0.1",
+    props: {
+      test: {
+        type: "dir",
         label: "Test",
       },
     },

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -11,9 +11,11 @@ const {
   missingPropsLabel,
   missingPropsLabelTimer,
   missingPropsLabelHttp,
+  missingPropsLabelDir,
   missingPropsDescription,
   missingPropsDescriptionTimer,
   missingPropsDescriptionHttp,
+  missingPropsDescriptionDir,
   badSourceName,
   badSourceDescription,
   tsVersion,
@@ -45,14 +47,16 @@ function withPrecedingStatement(code) {
 function makeComponentTestCase ({
   ruleName,
   name = `${ruleName}-test`,
-  validComponent = valid,
+  validComponents = [
+    valid,
+  ],
   invalidComponent,
   errorMessage,
 }) {
   return {
     name,
     ruleName,
-    validComponent,
+    validComponents,
     invalidComponent,
     errorMessage,
   };
@@ -91,25 +95,21 @@ const componentTestConfigs = [
   },
   {
     ruleName: "props-label",
-    validComponent: missingPropsLabelTimer,
-    invalidComponent: missingPropsLabel,
-    errorMessage: "Component prop test must have a label. See https://pipedream.com/docs/components/guidelines/#props",
-  },
-  {
-    ruleName: "props-label",
-    validComponent: missingPropsLabelHttp,
+    validComponents: [
+      missingPropsLabelTimer,
+      missingPropsLabelHttp,
+      missingPropsLabelDir,
+    ],
     invalidComponent: missingPropsLabel,
     errorMessage: "Component prop test must have a label. See https://pipedream.com/docs/components/guidelines/#props",
   },
   {
     ruleName: "props-description",
-    validComponent: missingPropsDescriptionTimer,
-    invalidComponent: missingPropsDescription,
-    errorMessage: "Component prop test must have a description. See https://pipedream.com/docs/components/guidelines/#props",
-  },
-  {
-    ruleName: "props-description",
-    validComponent: missingPropsDescriptionHttp,
+    validComponents: [
+      missingPropsDescriptionTimer,
+      missingPropsDescriptionHttp,
+      missingPropsDescriptionDir,
+    ],
     invalidComponent: missingPropsDescription,
     errorMessage: "Component prop test must have a description. See https://pipedream.com/docs/components/guidelines/#props",
   },
@@ -138,19 +138,19 @@ componentTestCases.forEach((testCase) => {
   const {
     name,
     ruleName,
-    validComponent,
+    validComponents,
     invalidComponent,
     errorMessage,
   } = testCase;
   ruleTester.run(name, rules[ruleName], {
-    valid: [
+    valid: validComponents.map((component) => ([
       {
-        code: convertObjectToCJSExportString(validComponent),
+        code: convertObjectToCJSExportString(component),
       },
       {
-        code: convertObjectToESMExportString(validComponent),
+        code: convertObjectToESMExportString(component),
       },
-    ],
+    ])).flat(),
     invalid: [
       {
         code: convertObjectToCJSExportString(invalidComponent),


### PR DESCRIPTION
- Stop requiring `label` and `description` properties for 'dir' props
- Refactor label/description exemption logic for props
- Add test cases for 'dir' type props in component tests
- Update `actions/checkout` and `actions/setup-node` to v4 in PR check WF to fix: `getCacheEntry failed: Cache service responded with 503`

Addresses this eslint warning:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/9073d7f9-3b8a-4d62-87f4-ae23e346c470" />

