### PR TITLE
build: setup CI/CD for package publishing

### DIFF
--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -1,0 +1,33 @@
+name: Publish Package to npm
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - name: npm publish (dry run)
+        if: github.ref != 'refs/heads/master'
+        run: npm publish --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: npm publish
+        if: github.ref == 'refs/heads/master'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-pipedream",
+  "name": "@pipedream/eslint-plugin-pipedream",
   "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-pipedream",
+  "name": "@pipedream/eslint-plugin-pipedream",
   "version": "0.2.4",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",


### PR DESCRIPTION
- Creates GitHub workflow to publish the package to npm on push to `master`
- Renames package from `eslint-plugin-pipedream` to `@pipedream/eslint-plugin-pipedream`  to publish in org scope

For reference, the [ESLint docs suggest](https://archive.eslint.org/docs/2.0.0/developer-guide/working-with-plugins) naming scoped packages `@<scope>/eslint-plugin-<plugin-name>`.