### PR TITLE
Adding ESLint rule for action component MCP annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/eslint-plugin-pipedream",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "ESLint plugin for Pipedream components: https://pipedream.com/docs/components/api/",
   "main": "index.js",
   "scripts": {

--- a/tests/components.js
+++ b/tests/components.js
@@ -174,4 +174,42 @@ module.exports = {
     type: "action",
     version: "0.0.{{ts}}",
   },
+  validActionWithAnnotations: {
+    key: "test",
+    name: "Test",
+    description: "foo",
+    type: "action",
+    version: "0.0.1",
+    annotations: {
+      destructiveHint: false,
+      openWorldHint: false,
+      readOnlyHint: true,
+    },
+  },
+  actionMissingAnnotations: {
+    key: "test",
+    name: "Test",
+    description: "foo",
+    type: "action",
+    version: "0.0.1",
+  },
+  actionMissingAnnotationKey: {
+    key: "test",
+    name: "Test",
+    description: "foo",
+    type: "action",
+    version: "0.0.1",
+    annotations: {
+      destructiveHint: false,
+      openWorldHint: false,
+    },
+  },
+  actionInvalidAnnotations: {
+    key: "test",
+    name: "Test",
+    description: "foo",
+    type: "action",
+    version: "0.0.1",
+    annotations: "invalid",
+  },
 };

--- a/tests/rules.test.js
+++ b/tests/rules.test.js
@@ -19,6 +19,10 @@ const {
   badSourceName,
   badSourceDescription,
   tsVersion,
+  validActionWithAnnotations,
+  actionMissingAnnotations,
+  actionMissingAnnotationKey,
+  actionInvalidAnnotations,
 } = require("./components");
 
 const ruleTester = new RuleTester({
@@ -128,6 +132,33 @@ const componentTestConfigs = [
     ruleName: "no-ts-version",
     invalidComponent: tsVersion,
     errorMessage: "{{ts}} macro should be removed before committing",
+  },
+  {
+    name: "action-annotations-missing",
+    ruleName: "action-annotations",
+    validComponents: [
+      validActionWithAnnotations,
+    ],
+    invalidComponent: actionMissingAnnotations,
+    errorMessage: "Action component is missing required 'annotations' object",
+  },
+  {
+    name: "action-annotations-missing-key",
+    ruleName: "action-annotations",
+    validComponents: [
+      validActionWithAnnotations,
+    ],
+    invalidComponent: actionMissingAnnotationKey,
+    errorMessage: "Property 'annotations' is missing required key: 'readOnlyHint'",
+  },
+  {
+    name: "action-annotations-invalid",
+    ruleName: "action-annotations",
+    validComponents: [
+      validActionWithAnnotations,
+    ],
+    invalidComponent: actionInvalidAnnotations,
+    errorMessage: "Property 'annotations' must be an object expression",
   },
 ];
 


### PR DESCRIPTION
This enforces that newly added action components have the `annotations` property correctly set up for MCP tool annotations.

Tested this by importing this updated package locally in the components repo, and adding the rule.

PR in the components repo to add this rule: https://github.com/PipedreamHQ/pipedream/pull/18676